### PR TITLE
Fix pulseplot being inverted for files starting with positive numbers

### DIFF
--- a/frontend/src/pages/Pulseplot.vue
+++ b/frontend/src/pages/Pulseplot.vue
@@ -113,6 +113,8 @@ export default defineComponent({
         }
       }
 
+      rawData = rawData.trim()
+
       if (rawData.startsWith('-')) {
         rawData = '0 ' + rawData
       }


### PR DESCRIPTION
`rawData` always started with a space, so `rawData.startsWith('-')` never triggered and `rawData.map(e => Number(e))` always interpreted the space as a 0.

After this fix files with and without negative start values are rendered correctly.